### PR TITLE
switch backend to rayon-core/crossbeam-deque

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ appveyor = { repository = "QuietMisdreavus/polyester" }
 [dependencies]
 num_cpus = "1"
 synchronoise = "0.4.0"
-crossbeam = "0.3.0"
+# crossbeam-deque 0.2.0 is the version used by rayon-core 1.4.0
+crossbeam-deque = "0.2.0"
 rayon-core = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ appveyor = { repository = "QuietMisdreavus/polyester" }
 num_cpus = "1"
 synchronoise = "0.4.0"
 crossbeam = "0.3.0"
+rayon-core = "1"


### PR DESCRIPTION
This is a bit of a demo to figure out what it would take to integrate polyester into rayon, to make one source of "parallel iterators" in the rust world.

The biggest win here is the use of rayon's thread pool, rather than spawning a loose bundle of threads and tracking the count on my own. I was also able to replace crossbeam's `chase_lev` deque with the newer `crossbeam-deque` crate, which is also used by `rayon-core`.

The biggest wildcards here are (1) the hopper algorithm, which could possibly leverage more things from rayon (i didn't look super thoroughly), and (2) the use of `synchronoise` as a thread synchronization technique, which still brings in vanilla `crossbeam` for its `MsQueue`. (The current implementations wants an MPMC, `Send`/`Sync` queue/container that i can stuff thread handles into so i can drain them from any other thread. Neither `std::mpsc` nor `crossbeam-deque` allow that. `>_>`)